### PR TITLE
Fix dependency graph action version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,4 +32,4 @@ jobs:
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+      uses: advanced-security/maven-dependency-submission-action@v5


### PR DESCRIPTION
## Summary
- use the stable version for the dependency submission action

## Testing
- no tests run since this change only updates the workflow configuration

------
https://chatgpt.com/codex/tasks/task_e_686e906934a48324a17571da709cf78d